### PR TITLE
Start and reset

### DIFF
--- a/Sources/TinyWorkflow.Tests/StartAndResetTest.cs
+++ b/Sources/TinyWorkflow.Tests/StartAndResetTest.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TinyWorkflow.Tests
+{
+    [TestClass]
+    public class StartAndResetTest
+    {
+        [TestMethod]
+        public void StartAndResetSingleStepWorkflow()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Do(c => c.Data = c.Data.ToUpper());
+
+            var contextData = "sample";
+            
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetMultipleTimes()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Do(c => c.Data = c.Data.ToUpper());
+
+            var contextData = "sample";
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetWithMultipleSteps()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Do(c => c.Data = c.Data.ToUpper())
+                .Do(c => c.Data = c.Data += c.Data)
+                .Do(c => c.Data = c.Data.ToLower());
+
+            var contextData = "sample";
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData + contextData, workflow.Workload.Data);
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData + contextData, workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetWithBlockingAction()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Do(c => c.Data = c.Data.ToUpper())
+                .Block(1)
+                .Do(c => c.Data += c.Data);
+
+            var contextData = "sample";
+            
+            //start and check state at which workflow should be blocked
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.Blocked, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+
+            //continue workflow and if it has been reset
+            workflow.Unblock();
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual((contextData + contextData).ToUpper(), workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetWithForeachWorkflow()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Do(c => c.Data += c.Data)
+                .Foreach(context => context.Data.ToCharArray(),
+                    context => context.Item2.Data += context.Item1.ToString().ToUpper());
+
+            var contextData = "sample";
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData + contextData + (contextData + contextData).ToUpper(), workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetWithWhileLoop()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .While(context => context.Data != context.Data.ToUpper(), context =>
+                {
+                    var charArray = context.Data.ToCharArray();
+                    for (int i = 0; i < charArray.Length; i++)
+                    {
+                        if (char.IsLower(charArray[i]))
+                        {
+                            charArray[i] = char.ToUpper(charArray[i]);
+                            context.Data = new string(charArray);
+                            break;
+                        }
+                    }
+                });
+
+            var contextData = "sample";
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(contextData.ToUpper(), workflow.Workload.Data);
+        }
+
+        [TestMethod]
+        public void StartAndResetWithMultipleWorkflows()
+        {
+            var workflow = new Workflow<SimpleWorkflowContext>()
+                .Foreach(context => context.Data.ToCharArray(), new Workflow<Tuple<char, SimpleWorkflowContext>>()
+                    .Do(context => context.Item2.Data += context.Item1)
+                    .Foreach(context => context.Item2.Data.ToCharArray(), new Workflow<Tuple<char, Tuple<char, SimpleWorkflowContext>>>()
+                        .Do(context => context.Item2.Item2.Data = context.Item2.Item2.Data.Substring(0,context.Item2.Item2.Data.Length - 1))
+                    )
+                );
+
+            var contextData = "sample";
+
+            workflow.StartAndReset(new SimpleWorkflowContext(contextData));
+            Assert.AreEqual(WorkflowState.NotRunning, workflow.State);
+            Assert.AreEqual(string.Empty, workflow.Workload.Data);
+        }
+
+        private class SimpleWorkflowContext
+        {
+            public string Data { get; set; }
+
+            public SimpleWorkflowContext(string data)
+            {
+                Data = data;
+            }
+        }
+    }
+}

--- a/Sources/TinyWorkflow.Tests/TinyWorkflow.Tests.csproj
+++ b/Sources/TinyWorkflow.Tests/TinyWorkflow.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="BugFixes\ForStepBugFixTest.cs" />
     <Compile Include="ComplexTest.cs" />
     <Compile Include="AsynchStepTest.cs" />
+    <Compile Include="StartAndResetTest.cs" />
     <Compile Include="States\ComplexState.cs" />
     <Compile Include="IfStepTest.cs" />
     <Compile Include="States\ConditionState.cs" />

--- a/Sources/TinyWorkflow/Actions/MultipleGoWorkflowAction.cs
+++ b/Sources/TinyWorkflow/Actions/MultipleGoWorkflowAction.cs
@@ -44,10 +44,7 @@ namespace TinyWorkflow.Actions
 
 		public override void Run(T obj)
 		{
-			foreach (var item in Actions)
-			{
-				Task.Factory.StartNew(() => item(obj));
-			}
+		    Task.Run(() => Parallel.ForEach(Actions, (action) => action(obj)));
 			state = WorkflowActionState.Ended;
 		}
 

--- a/Sources/TinyWorkflow/IWorkflow.cs
+++ b/Sources/TinyWorkflow/IWorkflow.cs
@@ -11,6 +11,8 @@ namespace TinyWorkflow
 
 		void Start(T workload);
 
+	    void StartAndReset(T workload);
+
 		void End();
 
 		void Reset();

--- a/Sources/TinyWorkflow/TinyWorkflow.csproj
+++ b/Sources/TinyWorkflow/TinyWorkflow.csproj
@@ -50,6 +50,7 @@
     <Compile Include="IWorkflow.cs" />
     <Compile Include="IWorkflowFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WorkflowStateChangedEventArgs.cs" />
     <Compile Include="Workflow.cs" />
     <Compile Include="WorkflowFactory.cs" />
     <Compile Include="WorkflowState.cs" />

--- a/Sources/TinyWorkflow/WorkflowStateChangedEventArgs.cs
+++ b/Sources/TinyWorkflow/WorkflowStateChangedEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TinyWorkflow
+{
+    public class WorkflowStateChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// New workflow state.
+        /// </summary>
+        public WorkflowState State { get; private set; }
+
+        public WorkflowStateChangedEventArgs(WorkflowState state)
+        {
+            State = state;
+        }
+    }
+}

--- a/Sources/TinyWorkflow/project.json
+++ b/Sources/TinyWorkflow/project.json
@@ -2,7 +2,8 @@
   "supports": {},
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.0",
+    "System.Threading.Tasks.Parallel": "4.3.0"
   },
   "frameworks": {
     "netstandard1.1": {}


### PR DESCRIPTION
I implemented a simple method StartAndReset which allows users to easily run workflow mutiple times synchronously (without using parallel option using DoAsynch method). I also added public event for workflow state change detection.

Last change is to use Parallel.Foreach instead of Task.Factory.StartNew in MultipleGoWorkflowAction for better performance when dealing with large number of items.

Added functionality should be covered with provided unit tests.